### PR TITLE
Process response headers

### DIFF
--- a/libmodsecurity/libmodsecurity_test.go
+++ b/libmodsecurity/libmodsecurity_test.go
@@ -8,6 +8,7 @@ import (
 var libmodsecurity *LibModSecurity
 
 func TestVar(t *testing.T) {
+	libmodsecurity.AddRule("SecRuleEngine On")
 	err := libmodsecurity.AddRule("SecRule REQUEST_LINE \"@contains php\" \"id:1,phase:1,deny\"")
 	if err != nil {
 		t.Fatal("cant add rule ", err)

--- a/libmodsecurity/transaction.go
+++ b/libmodsecurity/transaction.go
@@ -115,8 +115,12 @@ func (t *Transaction) AddResponseHeader(key, value string) {
 	C.msc_add_n_response_header(t.trans, cUKey, C.strlen(cKey), cUVal, C.strlen(cVal))
 }
 
-func (t *Transaction) ProcessResponseHeader() {
-	C.msc_process_response_headers(t.trans)
+func (t *Transaction) ProcessResponseHeader(code int, protocol string) {
+	cCode := C.int(code)
+	cProtocol := C.CString(protocol)
+	defer C.free(unsafe.Pointer(cProtocol))
+
+	C.msc_process_response_headers(t.trans, cCode, cProtocol)
 }
 
 func (t *Transaction) AppendResponseBody(body []byte) {

--- a/modsecurity/connection.go
+++ b/modsecurity/connection.go
@@ -89,7 +89,7 @@ func (m *connection) checkResponseHeader() (ok bool) {
 		}
 	}
 
-	m.trans.ProcessResponseHeader()
+	m.trans.ProcessResponseHeader(200, "http")
 	m.intervention = m.trans.Intervention()
 	if m.intervention != nil {
 		return true


### PR DESCRIPTION
This PR fixes the signature of the binded method `msc_process_response_headers` and enables the rule engine in the test